### PR TITLE
Enforce upload limits and avoid duplicate song files

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -75,7 +75,7 @@ const LyricsSearchApp = () => {
   const [selectedStatsFilter, setSelectedStatsFilter] = useState('all');
 
   // File upload hook
-  const fileUploadHook = useFileUpload(setSongs);
+  const fileUploadHook = useFileUpload(songs, setSongs);
   
   // Search hook
   const { searchResults } = useSearch(songs, searchQuery, highlightWord);

--- a/src/hooks/useFileUpload.js
+++ b/src/hooks/useFileUpload.js
@@ -1,36 +1,54 @@
 import { useState } from 'react';
 import DOMPurify from 'dompurify';
 
-export const useFileUpload = (setSongs) => {
+export const useFileUpload = (songs, setSongs) => {
   const [isDragging, setIsDragging] = useState(false);
 
   // File upload handler
   const handleFileUpload = async (files) => {
+    const existingFilenames = new Set(songs.map(song => song.filename));
+    const availableSlots = 50 - songs.length;
+    if (availableSlots <= 0) return;
+
+    const selectedFiles = [];
+
+    for (const file of files) {
+      if (selectedFiles.length >= availableSlots) break;
+
+      const sanitizedName = DOMPurify.sanitize(file.name);
+      if (existingFilenames.has(sanitizedName)) continue;
+
+      selectedFiles.push({ file, sanitizedName });
+      existingFilenames.add(sanitizedName);
+    }
+
     const newSongs = [];
-    
-    for (let file of files) {
+
+    for (const { file, sanitizedName } of selectedFiles) {
       if (file.type === 'text/plain' || file.name.endsWith('.txt')) {
         try {
           const content = await file.text();
           const songTitle = file.name.replace('.txt', '').replace(/[-_]/g, ' ');
-          
+
           const song = {
             id: Date.now() + Math.random(),
             title: DOMPurify.sanitize(songTitle),
             lyrics: DOMPurify.sanitize(content),
             wordCount: content.split(/\s+/).filter(word => word.length > 0).length,
             dateAdded: new Date().toISOString(),
-            filename: DOMPurify.sanitize(file.name)
+            filename: sanitizedName
           };
-          
+
           newSongs.push(song);
         } catch (error) {
           console.error(`Error reading file ${file.name}:`, error);
         }
       }
     }
-    
-    setSongs(prev => [...prev, ...newSongs]);
+
+    if (newSongs.length > 0) {
+      setSongs(prev => [...prev, ...newSongs]);
+    }
   };
 
   // Drag and drop handlers


### PR DESCRIPTION
## Summary
- limit processed uploads so total songs never exceed 50 and ignore files whose sanitized names already exist
- pass current songs state to the upload hook

## Testing
- `CI=true npm test --silent -- src/App.test.js` *(fails: TestingLibraryElementError: Unable to find an element with the text: /learn react/i)*

------
https://chatgpt.com/codex/tasks/task_e_68915f4cd71c8321ab88c3ccd5b9ea35