### PR TITLE
feat: add toast for save feedback

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -33,6 +33,7 @@ import AnalysisTab from './components/Tabs/AnalysisTab';
 import UploadTab from './components/Tabs/UploadTab';
 import StatsTab from './components/Tabs/StatsTab';
 import FloatingNotepad from './components/Notepad/FloatingNotepad';
+import StatusBanner from './components/Shared/StatusBanner';
 
 /* eslint-disable react-hooks/exhaustive-deps */
 
@@ -73,6 +74,9 @@ const LyricsSearchApp = () => {
   const [exampleSongDeleted, setExampleSongDeleted] = useState(() => loadExampleSongDeleted());
   // Stats filter
   const [selectedStatsFilter, setSelectedStatsFilter] = useState('all');
+
+  // UI feedback
+  const [saveMessage, setSaveMessage] = useState('');
 
   // File upload hook
   const fileUploadHook = useFileUpload(setSongs);
@@ -531,9 +535,9 @@ const LyricsSearchApp = () => {
     
     // Update original content to match current content
     setOriginalSongContent(notepadState.content);
-    
-    // Show success message
-    alert('Song saved successfully!');
+
+    // Show success message asynchronously
+    setSaveMessage('Song saved successfully!');
   };
 
   const handleRevertChanges = () => {
@@ -861,6 +865,11 @@ const LyricsSearchApp = () => {
         onStartNewContent={handleStartNewContent}
         hasUnsavedChanges={hasUnsavedChanges}
         originalSongContent={originalSongContent}
+      />
+      <StatusBanner
+        message={saveMessage}
+        onClose={() => setSaveMessage('')}
+        darkMode={darkMode}
       />
     </div>
   );

--- a/src/components/Shared/StatusBanner.js
+++ b/src/components/Shared/StatusBanner.js
@@ -1,0 +1,21 @@
+import React, { useEffect } from 'react';
+
+const StatusBanner = ({ message, onClose, darkMode }) => {
+  useEffect(() => {
+    if (!message) return;
+    const timer = setTimeout(onClose, 3000);
+    return () => clearTimeout(timer);
+  }, [message, onClose]);
+
+  if (!message) return null;
+
+  return (
+    <div
+      className={`fixed bottom-4 left-1/2 transform -translate-x-1/2 px-4 py-2 rounded shadow-lg ${darkMode ? 'bg-gray-800 text-white' : 'bg-green-100 text-green-800'}`}
+    >
+      {message}
+    </div>
+  );
+};
+
+export default StatusBanner;


### PR DESCRIPTION
## Summary
- show a non-blocking status banner when saving changes
- remove blocking alert from notepad save

## Testing
- `npm test --silent` *(fails: Unable to find an element with the text: /learn react/i)*

------
https://chatgpt.com/codex/tasks/task_e_68915f45b0408321ac7d285c40658a34