### PR TITLE
Flush pending notepad updates before unmount

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,11 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+jest.mock('jspdf', () => jest.fn());
+jest.mock('html2canvas', () => jest.fn());
+
+test('renders the music banner text', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const bannerText = screen.getByText(/check out my music/i);
+  expect(bannerText).toBeInTheDocument();
 });

--- a/src/hooks/useNotepad.js
+++ b/src/hooks/useNotepad.js
@@ -88,6 +88,8 @@ export const useNotepad = () => {
   useEffect(() => {
     return () => {
       if (saveTimeoutRef.current) {
+        saveToStorage(pendingUpdatesRef.current);
+        pendingUpdatesRef.current = {};
         clearTimeout(saveTimeoutRef.current);
       }
     };


### PR DESCRIPTION
## Summary
- ensure pending notepad updates are persisted before clearing debounced timer
- adjust test suite to look for music banner and mock heavy dependencies

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689cd6589130832184f45b3d68ad0539