### PR TITLE
Persist floating notepad dimensions

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders app component', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const header = screen.getByText(/check out my music/i);
+  expect(header).toBeInTheDocument();
 });

--- a/src/components/Notepad/FloatingNotepad.js
+++ b/src/components/Notepad/FloatingNotepad.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Edit3, Minimize2, Maximize2, Download, Upload, RotateCcw, Plus } from 'lucide-react';
 
 const FloatingNotepad = ({ 
@@ -19,8 +19,25 @@ const FloatingNotepad = ({
     dimensions,
     updateContent,
     updateTitle,
-    toggleMinimized
+    toggleMinimized,
+    updateDimensions
   } = notepadState;
+
+  const notepadRef = useRef(null);
+
+  useEffect(() => {
+    if (!notepadRef.current || isMinimized) return;
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect;
+        updateDimensions({ width, height });
+      }
+    });
+
+    observer.observe(notepadRef.current);
+    return () => observer.disconnect();
+  }, [isMinimized, updateDimensions]);
 
   const handleContentChange = (e) => {
     updateContent(e.target.value);
@@ -31,12 +48,13 @@ const FloatingNotepad = ({
   };
 
   return (
-    <div 
+    <div
+      ref={notepadRef}
       className={`fixed shadow-2xl border transition-all duration-300 ${
         isMinimized ? 'z-30 md:z-50 floating-notepad-minimized' : 'z-40'
       } ${
-        darkMode 
-          ? 'bg-gray-800 border-gray-600' 
+        darkMode
+          ? 'bg-gray-800 border-gray-600'
           : 'bg-white border-gray-300'
       } ${!isMinimized ? 'floating-notepad-expanded' : ''}`}
       style={

--- a/src/components/Notepad/FloatingNotepad.test.js
+++ b/src/components/Notepad/FloatingNotepad.test.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import FloatingNotepad from './FloatingNotepad';
+
+test('updates dimensions when resized', () => {
+  let resizeCb;
+  global.ResizeObserver = class {
+    constructor(cb) {
+      resizeCb = cb;
+    }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+
+  const updateDimensions = jest.fn();
+  const notepadState = {
+    content: '',
+    title: '',
+    isMinimized: false,
+    dimensions: { width: 200, height: 200 },
+    updateContent: jest.fn(),
+    updateTitle: jest.fn(),
+    toggleMinimized: jest.fn(),
+    updateDimensions,
+    currentEditingSongId: null
+  };
+
+  render(
+    <FloatingNotepad
+      notepadState={notepadState}
+      darkMode={false}
+      onExportTxt={() => {}}
+      onUploadToSongs={() => {}}
+      onSaveChanges={() => {}}
+      onRevertChanges={() => {}}
+      onStartNewContent={() => {}}
+      hasUnsavedChanges={false}
+      originalSongContent=""
+    />
+  );
+
+  resizeCb([{ contentRect: { width: 350, height: 260 } }]);
+  expect(updateDimensions).toHaveBeenCalledWith({ width: 350, height: 260 });
+});

--- a/src/hooks/useNotepad.test.js
+++ b/src/hooks/useNotepad.test.js
@@ -1,0 +1,23 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useNotepad } from './useNotepad';
+
+describe('useNotepad', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('restores dimensions from localStorage on reload', async () => {
+    const { result, unmount } = renderHook(() => useNotepad());
+
+    act(() => {
+      result.current.updateDimensions({ width: 300, height: 200 });
+    });
+
+    unmount();
+
+    const { result: result2 } = renderHook(() => useNotepad());
+    await waitFor(() => {
+      expect(result2.current.dimensions).toEqual({ width: 300, height: 200 });
+    });
+  });
+});

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -3,3 +3,28 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+// Mock canvas context used by libraries like jsPDF
+window.HTMLCanvasElement.prototype.getContext = () => ({});
+
+// Mock libraries that require browser-specific features
+jest.mock('jspdf', () => {
+  return jest.fn().mockImplementation(() => ({
+    text: jest.fn(),
+    save: jest.fn()
+  }));
+});
+
+jest.mock('html2canvas', () => jest.fn());
+
+// Provide a basic ResizeObserver mock
+class ResizeObserver {
+  constructor(callback) {
+    this.callback = callback;
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+global.ResizeObserver = ResizeObserver;


### PR DESCRIPTION
## Summary
- watch FloatingNotepad size with ResizeObserver and persist width/height
- mock canvas-dependent libs for tests
- add tests for resize detection and dimension restoration from localStorage

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689cd65f32308321a57b3d92cba4fb47