### PR TITLE
Fix App test conflict

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -6,6 +6,6 @@ jest.mock('html2canvas', () => jest.fn());
 
 test('renders the music banner text', () => {
   render(<App />);
-  const bannerText = screen.getByText(/check out my music/i);
-  expect(bannerText).toBeInTheDocument();
+  const musicBannerText = screen.getByText(/check out my music!/i);
+  expect(musicBannerText).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- update music banner unit test to match "Check out my music!" text
- retain jspdf and html2canvas mocks in App test

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689cdaba33e883218b37bb6e020194ee