### PR TITLE
Add auth service and JWT-secured song backend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,11 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
+        "cors": "^2.8.5",
         "dompurify": "^3.2.6",
+        "express": "^4.18.2",
         "html2canvas": "^1.4.1",
+        "jsonwebtoken": "^9.0.2",
         "jspdf": "^3.0.1",
         "lucide-react": "^0.511.0",
         "react": "^19.1.0",
@@ -5478,6 +5481,12 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -6111,6 +6120,19 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
@@ -7031,6 +7053,15 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -11251,6 +11282,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
     "node_modules/jspdf": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.1.tgz",
@@ -11282,6 +11335,27 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -11432,6 +11506,42 @@
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "license": "MIT"
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -11442,6 +11552,12 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/lodash.sortby": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "html2canvas": "^1.4.1",
     "jspdf": "^3.0.1",
     "lucide-react": "^0.511.0",
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-scripts": "5.0.1",
@@ -20,6 +23,7 @@
   },
   "scripts": {
     "start": "craco start",
+    "server": "node server/index.js",
     "build": "CI=false craco build",
     "test": "craco test",
     "eject": "react-scripts eject"

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,82 @@
+// Simple Express server providing authentication and song CRUD endpoints
+// Songs are stored in-memory for demonstration purposes
+
+const express = require('express');
+const cors = require('cors');
+const jwt = require('jsonwebtoken');
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const SECRET = 'super-secret-key';
+let songs = [];
+
+// Middleware to verify JWT token
+function authenticate(req, res, next) {
+  const authHeader = req.headers.authorization;
+  if (!authHeader) return res.sendStatus(401);
+
+  const token = authHeader.split(' ')[1];
+  jwt.verify(token, SECRET, (err, user) => {
+    if (err) return res.sendStatus(403);
+    req.user = user;
+    next();
+  });
+}
+
+// Auth routes
+app.post('/api/auth/login', (req, res) => {
+  const { username, password } = req.body;
+  // For demo purposes accept a single hard-coded user
+  if (username === 'user' && password === 'password') {
+    const token = jwt.sign({ username }, SECRET, { expiresIn: '1h' });
+    return res.json({ token });
+  }
+  return res.status(401).json({ error: 'Invalid credentials' });
+});
+
+app.post('/api/auth/refresh', authenticate, (req, res) => {
+  const token = jwt.sign({ username: req.user.username }, SECRET, { expiresIn: '1h' });
+  res.json({ token });
+});
+
+// Song CRUD endpoints
+app.get('/api/songs', authenticate, (req, res) => {
+  res.json(songs);
+});
+
+app.post('/api/songs', authenticate, (req, res) => {
+  const song = { id: Date.now().toString(), ...req.body };
+  songs.push(song);
+  res.status(201).json(song);
+});
+
+app.put('/api/songs/:id', authenticate, (req, res) => {
+  const idx = songs.findIndex(s => s.id === req.params.id);
+  if (idx === -1) return res.sendStatus(404);
+  songs[idx] = { ...songs[idx], ...req.body };
+  res.json(songs[idx]);
+});
+
+app.delete('/api/songs/:id', authenticate, (req, res) => {
+  songs = songs.filter(s => s.id !== req.params.id);
+  res.sendStatus(204);
+});
+
+// Bulk update/clear helpers used by the frontend
+app.put('/api/songs', authenticate, (req, res) => {
+  songs = Array.isArray(req.body) ? req.body : [];
+  res.json(songs);
+});
+
+app.delete('/api/songs', authenticate, (req, res) => {
+  songs = [];
+  res.sendStatus(204);
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});
+

--- a/src/App.js
+++ b/src/App.js
@@ -13,6 +13,7 @@ import {
 import { analyzeRhymeStatistics } from './utils/phoneticUtils';
 import { songVocabularyPhoneticMap } from './data/songVocabularyPhoneticMap';
 import { saveUserSongs, loadUserSongs, clearUserSongs, saveExampleSongDeleted, loadExampleSongDeleted } from './utils/songStorage';
+import { login as authLogin, logout as authLogout, getToken } from './services/authService';
 
 // Import hooks
 import { useSearchHistory, useDarkMode, useHighlightWord } from './hooks/useLocalStorage';
@@ -42,6 +43,7 @@ const LyricsSearchApp = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const [activeTab, setActiveTab] = useState('upload');
   const [selectedSong, setSelectedSong] = useState(null);
+  const [token, setToken] = useState(getToken());
   
   // Use custom hooks for localStorage
   const [searchHistory, setSearchHistory] = useSearchHistory();
@@ -92,6 +94,25 @@ const LyricsSearchApp = () => {
   // Load example song only when needed
   const loadingExampleRef = useRef(false);
   const [userSongsLoaded, setUserSongsLoaded] = useState(false);
+  const isAuthenticated = !!token;
+
+  const handleLogin = async () => {
+    const username = prompt('Username');
+    const password = prompt('Password');
+    try {
+      const newToken = await authLogin(username, password);
+      setToken(newToken);
+    } catch (error) {
+      alert('Login failed');
+    }
+  };
+
+  const handleLogout = () => {
+    authLogout();
+    setToken(null);
+    setSongs([]);
+    setUserSongsLoaded(false);
+  };
   
   useEffect(() => {
     const loadExampleSong = async () => {
@@ -144,33 +165,26 @@ const LyricsSearchApp = () => {
     }
   }, [songs.length, exampleSongDeleted, userSongsLoaded]);
 
-  // Load persisted user songs on app startup
+  // Load persisted user songs from server when authenticated
   useEffect(() => {
-    const loadPersistedSongs = () => {
-      const userSongs = loadUserSongs();
+    const loadPersistedSongs = async () => {
+      if (!token) return;
+      const userSongs = await loadUserSongs();
       if (userSongs.length > 0) {
-        setSongs(prev => {
-          // Only add if not already present (avoid duplicates)
-          const existingIds = new Set(prev.map(song => song.id));
-          const newSongs = userSongs.filter(song => !existingIds.has(song.id));
-          return [...prev, ...newSongs];
-        });
+        setSongs(userSongs);
       }
-      // Mark that user songs loading is complete (whether we found any or not)
       setUserSongsLoaded(true);
     };
 
-    // Load persisted songs on initial render
     loadPersistedSongs();
-  }, []); // Empty dependency array - only run once on mount
+  }, [token]);
 
   // Persist user songs whenever songs change
   useEffect(() => {
-    // Only save if we have songs and they're not just the initial load
-    if (songs.length > 0) {
+    if (token) {
       saveUserSongs(songs);
     }
-  }, [songs]);
+  }, [songs, token]);
 
   // Reset stats filter when songs change
   useEffect(() => {
@@ -644,13 +658,16 @@ const LyricsSearchApp = () => {
       <MusicBanner />
 
       {/* Header */}
-      <Header 
+      <Header
         activeTab={activeTab}
         setActiveTab={setActiveTab}
         showManual={showManual}
         setShowManual={setShowManual}
         darkMode={darkMode}
         setDarkMode={setDarkMode}
+        isAuthenticated={isAuthenticated}
+        onLogin={handleLogin}
+        onLogout={handleLogout}
       />
 
       {/* Universal Search Bar */}

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders app header', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/Lyrical-Toolkit/i);
+  expect(heading).toBeInTheDocument();
 });

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,13 +1,16 @@
 import React, { useState, useEffect } from 'react';
 import { Search, Upload, BarChart3, Book, Shuffle, Music, Moon, Sun } from 'lucide-react';
 
-const Header = ({ 
-  activeTab, 
-  setActiveTab, 
-  showManual, 
-  setShowManual, 
-  darkMode, 
-  setDarkMode 
+const Header = ({
+  activeTab,
+  setActiveTab,
+  showManual,
+  setShowManual,
+  darkMode,
+  setDarkMode,
+  isAuthenticated,
+  onLogin,
+  onLogout
 }) => {
   const [isMobile, setIsMobile] = useState(false);
 
@@ -31,8 +34,8 @@ const Header = ({
             <button
               onClick={() => setDarkMode(!darkMode)}
               className={`p-2 rounded-lg transition-colors ${
-                darkMode 
-                  ? 'bg-gray-700 hover:bg-gray-600' 
+                darkMode
+                  ? 'bg-gray-700 hover:bg-gray-600'
                   : 'bg-gray-100 hover:bg-gray-200 text-gray-600'
               }`}
               style={darkMode ? { color: 'white' } : {}}
@@ -40,26 +43,53 @@ const Header = ({
             >
               {darkMode ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
             </button>
-            
+
             <h1 className={`text-xl font-bold ${darkMode ? 'text-white' : 'text-black'}`}>
               Lyrical-Toolkit
             </h1>
-            
-            <button
-              onClick={() => setShowManual(!showManual)}
-              className={`p-2 rounded-lg transition-colors ${
-                showManual
-                  ? darkMode 
-                    ? 'bg-blue-600 text-white' 
-                    : 'bg-blue-600 text-white'
-                  : darkMode
-                    ? 'bg-gray-700 text-gray-300 hover:bg-gray-600 hover:text-white'
-                    : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
-              }`}
-              title="Show Manual"
-            >
-              <Book className="w-4 h-4" />
-            </button>
+
+            <div className="flex gap-2">
+              <button
+                onClick={() => setShowManual(!showManual)}
+                className={`p-2 rounded-lg transition-colors ${
+                  showManual
+                    ? darkMode
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-blue-600 text-white'
+                    : darkMode
+                      ? 'bg-gray-700 text-gray-300 hover:bg-gray-600 hover:text-white'
+                      : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+                }`}
+                title="Show Manual"
+              >
+                <Book className="w-4 h-4" />
+              </button>
+              {isAuthenticated ? (
+                <button
+                  onClick={onLogout}
+                  className={`p-2 rounded-lg transition-colors ${
+                    darkMode
+                      ? 'bg-red-700 text-red-200 hover:bg-red-600 hover:text-white'
+                      : 'bg-red-200 text-red-800 hover:bg-red-300'
+                  }`}
+                  title="Logout"
+                >
+                  Logout
+                </button>
+              ) : (
+                <button
+                  onClick={onLogin}
+                  className={`p-2 rounded-lg transition-colors ${
+                    darkMode
+                      ? 'bg-green-700 text-green-200 hover:bg-green-600 hover:text-white'
+                      : 'bg-green-200 text-green-800 hover:bg-green-300'
+                  }`}
+                  title="Login"
+                >
+                  Login
+                </button>
+              )}
+            </div>
           </div>
           
           {/* Mobile tabs */}
@@ -191,21 +221,46 @@ const Header = ({
           </div>
           
           <div style={{ display: 'table-cell', width: '33.33%', verticalAlign: 'middle', textAlign: 'right' }}>
-            <button
-              onClick={() => setShowManual(!showManual)}
-              className={`px-6 py-2 rounded-lg font-medium transition-colors ${
-                showManual
-                  ? darkMode 
-                    ? 'bg-blue-600 text-white' 
-                    : 'bg-blue-600 text-white'
-                  : darkMode
-                    ? 'bg-gray-700 text-gray-300 hover:bg-gray-600 hover:text-white'
-                    : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
-              }`}
-            >
-              <Book className="w-4 h-4 inline mr-2" />
-              Show Manual
-            </button>
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.5rem' }}>
+              <button
+                onClick={() => setShowManual(!showManual)}
+                className={`px-6 py-2 rounded-lg font-medium transition-colors ${
+                  showManual
+                    ? darkMode
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-blue-600 text-white'
+                    : darkMode
+                      ? 'bg-gray-700 text-gray-300 hover:bg-gray-600 hover:text-white'
+                      : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+                }`}
+              >
+                <Book className="w-4 h-4 inline mr-2" />
+                Show Manual
+              </button>
+              {isAuthenticated ? (
+                <button
+                  onClick={onLogout}
+                  className={`px-6 py-2 rounded-lg font-medium transition-colors ${
+                    darkMode
+                      ? 'bg-red-700 text-red-200 hover:bg-red-600 hover:text-white'
+                      : 'bg-red-200 text-red-800 hover:bg-red-300'
+                  }`}
+                >
+                  Logout
+                </button>
+              ) : (
+                <button
+                  onClick={onLogin}
+                  className={`px-6 py-2 rounded-lg font-medium transition-colors ${
+                    darkMode
+                      ? 'bg-green-700 text-green-200 hover:bg-green-600 hover:text-white'
+                      : 'bg-green-200 text-green-800 hover:bg-green-300'
+                  }`}
+                >
+                  Login
+                </button>
+              )}
+            </div>
           </div>
         </div>
         

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -1,0 +1,66 @@
+// Authentication service for handling login/logout and token refresh
+// Uses localStorage to persist the auth token and communicates with
+// the backend at /api/auth
+
+const AUTH_API = '/api/auth';
+
+// Retrieve the current auth token from localStorage
+export const getToken = () => {
+  return localStorage.getItem('authToken');
+};
+
+// Save a token to localStorage
+const setToken = (token) => {
+  if (token) {
+    localStorage.setItem('authToken', token);
+  }
+};
+
+// Clear the stored token
+export const logout = () => {
+  localStorage.removeItem('authToken');
+};
+
+// Login with username and password. On success the token is stored and returned.
+export const login = async (username, password) => {
+  const response = await fetch(`${AUTH_API}/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password })
+  });
+
+  if (!response.ok) {
+    throw new Error('Login failed');
+  }
+
+  const data = await response.json();
+  setToken(data.token);
+  return data.token;
+};
+
+// Refresh the current token. Returns and stores the new token.
+export const refreshToken = async () => {
+  const token = getToken();
+  if (!token) throw new Error('No token available');
+
+  const response = await fetch(`${AUTH_API}/refresh`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` }
+  });
+
+  if (!response.ok) {
+    throw new Error('Token refresh failed');
+  }
+
+  const data = await response.json();
+  setToken(data.token);
+  return data.token;
+};
+
+export default {
+  login,
+  logout,
+  refreshToken,
+  getToken
+};
+


### PR DESCRIPTION
## Summary
- add `authService` with login, logout and token refresh helpers
- implement Express server with `/api/auth` and JWT-protected `/api/songs` CRUD endpoints
- persist songs on server via new async storage helpers and fetch after login
- expose login/logout controls in header and load songs after authentication
- update unit test to assert app header renders

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689cd856b5a48321bd4c284d933cecae