### PR TITLE
feat: add authentication modal with login and signup

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -33,6 +33,7 @@ import AnalysisTab from './components/Tabs/AnalysisTab';
 import UploadTab from './components/Tabs/UploadTab';
 import StatsTab from './components/Tabs/StatsTab';
 import FloatingNotepad from './components/Notepad/FloatingNotepad';
+import AuthModal from './components/AuthModal';
 
 /* eslint-disable react-hooks/exhaustive-deps */
 
@@ -74,6 +75,11 @@ const LyricsSearchApp = () => {
   // Stats filter
   const [selectedStatsFilter, setSelectedStatsFilter] = useState('all');
 
+  // Authentication modal state
+  const [showAuthModal, setShowAuthModal] = useState(false);
+  const [authMode, setAuthMode] = useState('login');
+  const [token, setToken] = useState(null);
+
   // File upload hook
   const fileUploadHook = useFileUpload(songs, setSongs);
   
@@ -92,6 +98,18 @@ const LyricsSearchApp = () => {
   // Load example song only when needed
   const loadingExampleRef = useRef(false);
   const [userSongsLoaded, setUserSongsLoaded] = useState(false);
+
+  const openAuthModal = (mode = 'login') => {
+    setAuthMode(mode);
+    setShowAuthModal(true);
+  };
+
+  const handleAuthSuccess = (data) => {
+    if (data?.token) {
+      setToken(data.token);
+    }
+    setShowAuthModal(false);
+  };
   
   useEffect(() => {
     const loadExampleSong = async () => {
@@ -644,13 +662,16 @@ const LyricsSearchApp = () => {
       <MusicBanner />
 
       {/* Header */}
-      <Header 
+      <Header
         activeTab={activeTab}
         setActiveTab={setActiveTab}
         showManual={showManual}
         setShowManual={setShowManual}
         darkMode={darkMode}
         setDarkMode={setDarkMode}
+        isAuthenticated={!!token}
+        onLoginClick={() => openAuthModal('login')}
+        onSignupClick={() => openAuthModal('signup')}
       />
 
       {/* Universal Search Bar */}
@@ -853,8 +874,15 @@ const LyricsSearchApp = () => {
         )}
       </div>
 
+      <AuthModal
+        isOpen={showAuthModal}
+        mode={authMode}
+        onClose={() => setShowAuthModal(false)}
+        onSuccess={handleAuthSuccess}
+      />
+
       {/* Song Modal */}
-      <SongModal 
+      <SongModal
         selectedSong={selectedSong}
         onClose={() => setSelectedSong(null)}
         highlightWord={highlightWord}

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,11 +1,5 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
-
-test('renders app component', () => {
-  render(<App />);
-  const header = screen.getByText(/check out my music/i);
-  expect(header).toBeInTheDocument();
-=======
 jest.mock('jspdf', () => jest.fn());
 jest.mock('html2canvas', () => jest.fn());
 

--- a/src/components/AuthModal.js
+++ b/src/components/AuthModal.js
@@ -1,0 +1,85 @@
+import React, { useState, useEffect } from 'react';
+import authService from '../services/authService';
+
+const AuthModal = ({ isOpen, mode: initialMode = 'login', onClose, onSuccess }) => {
+  const [mode, setMode] = useState(initialMode);
+
+  useEffect(() => {
+    setMode(initialMode);
+  }, [initialMode]);
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState(null);
+
+  const switchMode = (newMode) => {
+    setMode(newMode);
+    setError(null);
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      let result;
+      if (mode === 'login') {
+        result = await authService.login(username, password);
+      } else {
+        result = await authService.signup(username, password);
+      }
+      if (onSuccess) {
+        onSuccess(result);
+      }
+      setUsername('');
+      setPassword('');
+    } catch (err) {
+      setError(err.message || 'Authentication failed');
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+      <div className="bg-white dark:bg-gray-800 p-6 rounded shadow-md w-80">
+        <div className="flex mb-4">
+          <button
+            className={`flex-1 px-3 py-2 rounded-t ${mode === 'login' ? 'bg-gray-200 dark:bg-gray-700' : ''}`}
+            onClick={() => switchMode('login')}
+          >
+            Login
+          </button>
+          <button
+            className={`flex-1 px-3 py-2 rounded-t ${mode === 'signup' ? 'bg-gray-200 dark:bg-gray-700' : ''}`}
+            onClick={() => switchMode('signup')}
+          >
+            Sign Up
+          </button>
+        </div>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            type="text"
+            placeholder="Username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            className="w-full p-2 border rounded"
+          />
+          <input
+            type="password"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full p-2 border rounded"
+          />
+          {error && <div className="text-red-500 text-sm">{error}</div>}
+          <div className="flex justify-end space-x-2">
+            <button type="button" onClick={onClose} className="px-4 py-2 rounded bg-gray-300">Cancel</button>
+            <button type="submit" className="px-4 py-2 rounded bg-blue-600 text-white">
+              {mode === 'login' ? 'Login' : 'Sign Up'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default AuthModal;

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,13 +1,16 @@
 import React, { useState, useEffect } from 'react';
 import { Search, Upload, BarChart3, Book, Shuffle, Music, Moon, Sun } from 'lucide-react';
 
-const Header = ({ 
-  activeTab, 
-  setActiveTab, 
-  showManual, 
-  setShowManual, 
-  darkMode, 
-  setDarkMode 
+const Header = ({
+  activeTab,
+  setActiveTab,
+  showManual,
+  setShowManual,
+  darkMode,
+  setDarkMode,
+  isAuthenticated,
+  onLoginClick,
+  onSignupClick
 }) => {
   const [isMobile, setIsMobile] = useState(false);
 
@@ -45,21 +48,45 @@ const Header = ({
               Lyrical-Toolkit
             </h1>
             
-            <button
-              onClick={() => setShowManual(!showManual)}
-              className={`p-2 rounded-lg transition-colors ${
-                showManual
-                  ? darkMode 
-                    ? 'bg-blue-600 text-white' 
-                    : 'bg-blue-600 text-white'
-                  : darkMode
-                    ? 'bg-gray-700 text-gray-300 hover:bg-gray-600 hover:text-white'
-                    : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
-              }`}
-              title="Show Manual"
-            >
-              <Book className="w-4 h-4" />
-            </button>
+            <div className="flex items-center gap-2">
+              {!isAuthenticated && (
+                <>
+                  <button
+                    onClick={onLoginClick}
+                    className={`px-3 py-2 rounded-lg transition-colors ${
+                      darkMode
+                        ? 'bg-gray-700 text-gray-300 hover:bg-gray-600 hover:text-white'
+                        : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+                    }`}
+                  >
+                    Login
+                  </button>
+                  <button
+                    onClick={onSignupClick}
+                    className={`px-3 py-2 rounded-lg transition-colors ${
+                      darkMode
+                        ? 'bg-gray-700 text-gray-300 hover:bg-gray-600 hover:text-white'
+                        : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+                    }`}
+                  >
+                    Sign Up
+                  </button>
+                </>
+              )}
+              <button
+                onClick={() => setShowManual(!showManual)}
+                className={`p-2 rounded-lg transition-colors ${
+                  showManual
+                    ? 'bg-blue-600 text-white'
+                    : darkMode
+                      ? 'bg-gray-700 text-gray-300 hover:bg-gray-600 hover:text-white'
+                      : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+                }`}
+                title="Show Manual"
+              >
+                <Book className="w-4 h-4" />
+              </button>
+            </div>
           </div>
           
           {/* Mobile tabs */}
@@ -191,21 +218,47 @@ const Header = ({
           </div>
           
           <div style={{ display: 'table-cell', width: '33.33%', verticalAlign: 'middle', textAlign: 'right' }}>
-            <button
-              onClick={() => setShowManual(!showManual)}
-              className={`px-6 py-2 rounded-lg font-medium transition-colors ${
-                showManual
-                  ? darkMode 
-                    ? 'bg-blue-600 text-white' 
-                    : 'bg-blue-600 text-white'
-                  : darkMode
-                    ? 'bg-gray-700 text-gray-300 hover:bg-gray-600 hover:text-white'
-                    : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
-              }`}
-            >
-              <Book className="w-4 h-4 inline mr-2" />
-              Show Manual
-            </button>
+            <div className="flex justify-end gap-2">
+              {!isAuthenticated && (
+                <>
+                  <button
+                    onClick={onLoginClick}
+                    className={`px-6 py-2 rounded-lg font-medium transition-colors ${
+                      darkMode
+                        ? 'bg-gray-700 text-gray-300 hover:bg-gray-600 hover:text-white'
+                        : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+                    }`}
+                  >
+                    Login
+                  </button>
+                  <button
+                    onClick={onSignupClick}
+                    className={`px-6 py-2 rounded-lg font-medium transition-colors ${
+                      darkMode
+                        ? 'bg-gray-700 text-gray-300 hover:bg-gray-600 hover:text-white'
+                        : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+                    }`}
+                  >
+                    Sign Up
+                  </button>
+                </>
+              )}
+              <button
+                onClick={() => setShowManual(!showManual)}
+                className={`px-6 py-2 rounded-lg font-medium transition-colors ${
+                  showManual
+                    ? darkMode
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-blue-600 text-white'
+                    : darkMode
+                      ? 'bg-gray-700 text-gray-300 hover:bg-gray-600 hover:text-white'
+                      : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+                }`}
+              >
+                <Book className="w-4 h-4 inline mr-2" />
+                Show Manual
+              </button>
+            </div>
           </div>
         </div>
         

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -1,0 +1,27 @@
+const API_BASE = '/api';
+
+export async function login(username, password) {
+  const res = await fetch(`${API_BASE}/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password })
+  });
+  if (!res.ok) {
+    throw new Error('Login failed');
+  }
+  return res.json();
+}
+
+export async function signup(username, password) {
+  const res = await fetch(`${API_BASE}/signup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password })
+  });
+  if (!res.ok) {
+    throw new Error('Signup failed');
+  }
+  return res.json();
+}
+
+export default { login, signup };


### PR DESCRIPTION
## Summary
- add AuthModal component with toggle for login or sign up using authService
- introduce authService for communicating with backend auth endpoints
- manage auth modal state and token in App and expose login/signup buttons in Header

## Testing
- `npm test -- --watchAll=false` *(fails: TypeError in FloatingNotepad.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_689d4afddf0883218a0b53fadb81bf3e