### PR TITLE
Add signup auth flow and modal

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -11,6 +11,7 @@ app.use(express.json());
 
 const SECRET = 'super-secret-key';
 let songs = [];
+let users = [{ username: 'user', password: 'password' }];
 
 // Middleware to verify JWT token
 function authenticate(req, res, next) {
@@ -26,10 +27,27 @@ function authenticate(req, res, next) {
 }
 
 // Auth routes
+app.post('/api/auth/signup', (req, res) => {
+  const { username, password } = req.body;
+  if (!username || !password) {
+    return res.status(400).json({ error: 'Username and password required' });
+  }
+
+  const existing = users.find(u => u.username === username);
+  if (existing) {
+    return res.status(400).json({ error: 'User already exists' });
+  }
+
+  const newUser = { username, password };
+  users.push(newUser);
+  const token = jwt.sign({ username }, SECRET, { expiresIn: '1h' });
+  res.status(201).json({ token });
+});
+
 app.post('/api/auth/login', (req, res) => {
   const { username, password } = req.body;
-  // For demo purposes accept a single hard-coded user
-  if (username === 'user' && password === 'password') {
+  const user = users.find(u => u.username === username && u.password === password);
+  if (user) {
     const token = jwt.sign({ username }, SECRET, { expiresIn: '1h' });
     return res.json({ token });
   }

--- a/src/App.js
+++ b/src/App.js
@@ -13,7 +13,7 @@ import {
 import { analyzeRhymeStatistics } from './utils/phoneticUtils';
 import { songVocabularyPhoneticMap } from './data/songVocabularyPhoneticMap';
 import { saveUserSongs, loadUserSongs, clearUserSongs, saveExampleSongDeleted, loadExampleSongDeleted } from './utils/songStorage';
-import { login as authLogin, logout as authLogout, getToken } from './services/authService';
+import { logout as authLogout, getToken } from './services/authService';
 
 // Import hooks
 import { useSearchHistory, useDarkMode, useHighlightWord } from './hooks/useLocalStorage';
@@ -34,6 +34,7 @@ import AnalysisTab from './components/Tabs/AnalysisTab';
 import UploadTab from './components/Tabs/UploadTab';
 import StatsTab from './components/Tabs/StatsTab';
 import FloatingNotepad from './components/Notepad/FloatingNotepad';
+import AuthModal from './components/AuthModal';
 
 /* eslint-disable react-hooks/exhaustive-deps */
 
@@ -96,16 +97,10 @@ const LyricsSearchApp = () => {
   const loadingExampleRef = useRef(false);
   const [userSongsLoaded, setUserSongsLoaded] = useState(!initialToken);
   const isAuthenticated = !!token;
-
-  const handleLogin = async () => {
-    const username = prompt('Username');
-    const password = prompt('Password');
-    try {
-      const newToken = await authLogin(username, password);
-      setToken(newToken);
-    } catch (error) {
-      alert('Login failed');
-    }
+  const [showAuthModal, setShowAuthModal] = useState(false);
+  const handleAuth = (newToken) => {
+    setToken(newToken);
+    setShowAuthModal(false);
   };
 
   const handleLogout = () => {
@@ -113,6 +108,7 @@ const LyricsSearchApp = () => {
     setToken(null);
     setSongs([]);
     setUserSongsLoaded(false);
+    setShowAuthModal(false);
   };
   
   useEffect(() => {
@@ -670,8 +666,15 @@ const LyricsSearchApp = () => {
         darkMode={darkMode}
         setDarkMode={setDarkMode}
         isAuthenticated={isAuthenticated}
-        onLogin={handleLogin}
+        onLogin={() => setShowAuthModal(true)}
         onLogout={handleLogout}
+      />
+
+      <AuthModal
+        isOpen={showAuthModal}
+        onClose={() => setShowAuthModal(false)}
+        onAuth={handleAuth}
+        darkMode={darkMode}
       />
 
       {/* Universal Search Bar */}

--- a/src/components/AuthModal.js
+++ b/src/components/AuthModal.js
@@ -1,0 +1,74 @@
+import React, { useState } from 'react';
+import { login, signup } from '../services/authService';
+
+const AuthModal = ({ isOpen, onClose, onAuth, darkMode }) => {
+  const [mode, setMode] = useState('login');
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  if (!isOpen) return null;
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const token = mode === 'login'
+        ? await login(username, password)
+        : await signup(username, password);
+      onAuth(token);
+      setUsername('');
+      setPassword('');
+      setError('');
+    } catch (err) {
+      setError(mode === 'login' ? 'Login failed' : 'Sign up failed');
+    }
+  };
+
+  const toggleMode = () => {
+    setMode(mode === 'login' ? 'signup' : 'login');
+    setError('');
+  };
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+      <div className={`relative p-6 rounded shadow-lg w-80 ${darkMode ? 'bg-gray-800 text-white' : 'bg-white text-black'}`}>
+        <button
+          onClick={onClose}
+          className="absolute top-2 right-2 text-xl"
+          aria-label="Close"
+        >
+          &times;
+        </button>
+        <h2 className="text-xl mb-4 text-center">{mode === 'login' ? 'Login' : 'Sign Up'}</h2>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            type="text"
+            placeholder="Username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            className={`w-full px-3 py-2 border rounded ${darkMode ? 'bg-gray-700 border-gray-600' : ''}`}
+          />
+          <input
+            type="password"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className={`w-full px-3 py-2 border rounded ${darkMode ? 'bg-gray-700 border-gray-600' : ''}`}
+          />
+          {error && <div className="text-red-500 text-sm">{error}</div>}
+          <button
+            type="submit"
+            className={`w-full py-2 rounded ${darkMode ? 'bg-blue-600 hover:bg-blue-700' : 'bg-blue-500 hover:bg-blue-600 text-white'}`}
+          >
+            {mode === 'login' ? 'Login' : 'Sign Up'}
+          </button>
+        </form>
+        <button onClick={toggleMode} className="mt-4 text-sm text-blue-500">
+          {mode === 'login' ? 'Need an account? Sign Up' : 'Have an account? Login'}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default AuthModal;

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -84,9 +84,9 @@ const Header = ({
                       ? 'bg-green-700 text-green-200 hover:bg-green-600 hover:text-white'
                       : 'bg-green-200 text-green-800 hover:bg-green-300'
                   }`}
-                  title="Login"
+                  title="Login or Sign Up"
                 >
-                  Login
+                  Login / Sign Up
                 </button>
               )}
             </div>
@@ -257,7 +257,7 @@ const Header = ({
                       : 'bg-green-200 text-green-800 hover:bg-green-300'
                   }`}
                 >
-                  Login
+                  Login / Sign Up
                 </button>
               )}
             </div>

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -38,6 +38,23 @@ export const login = async (username, password) => {
   return data.token;
 };
 
+// Sign up with username and password. On success the token is stored and returned.
+export const signup = async (username, password) => {
+  const response = await fetch(`${AUTH_API}/signup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password })
+  });
+
+  if (!response.ok) {
+    throw new Error('Signup failed');
+  }
+
+  const data = await response.json();
+  setToken(data.token);
+  return data.token;
+};
+
 // Refresh the current token. Returns and stores the new token.
 export const refreshToken = async () => {
   const token = getToken();
@@ -59,6 +76,7 @@ export const refreshToken = async () => {
 
 export default {
   login,
+  signup,
   logout,
   refreshToken,
   getToken


### PR DESCRIPTION
## Summary
- Add in-memory user store with /api/auth/signup and validate login against stored users
- Introduce signup logic in authService and new AuthModal for login/sign up
- Replace prompt-based auth with modal and updated header text

## Testing
- `npm test -- --watchAll=false` (fails: SyntaxError in App.test.js, FloatingNotepad test TypeError)


------
https://chatgpt.com/codex/tasks/task_e_689d556b8f6c8321a1cfab9e60894f91